### PR TITLE
Add basic CI matrix & dependencies: Add strict version boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+env:
+  BUNDLE_WITHOUT: release
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
+      - name: Verify gem builds
+        run: gem build --strict --verbose *.gemspec
+
+  tests:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/smart_proxy_hdm.gemspec
+++ b/smart_proxy_hdm.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new('>= 2.7')
 
-  s.add_development_dependency('rake')
-  s.add_development_dependency('mocha')
-  s.add_development_dependency('minitest')
+  s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
+  s.add_development_dependency 'mocha', '~> 2.0', '>= 2.0.4'
+  s.add_development_dependency 'minitest', '~> 5.18'
 end


### PR DESCRIPTION
This follows the rubygems recommendation/styleguide. It's also used across the Vox Pupuli gems.