### PR TITLE
Set Ruby 2.7 as minimal version

### DIFF
--- a/smart_proxy_hdm.gemspec
+++ b/smart_proxy_hdm.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.files       = Dir['{config,lib,bundler.d}/**/*'] + ['README.md', 'LICENSE']
   s.test_files  = Dir['test/**/*']
 
+  s.required_ruby_version = Gem::Requirement.new('>= 2.7')
+
   s.add_development_dependency('rake')
   s.add_development_dependency('mocha')
   s.add_development_dependency('minitest')


### PR DESCRIPTION
```
10:39:09   bastelfreak | Zhenech: what's the lowest ruby version the plugins need to support?
10:50:54       Zhenech | bastelfreak, =2.7
```